### PR TITLE
docs: change some note related to darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ There are 3 main templates in this repository:
 1. Run `nix flake new -t github:auxolotl/templates#darwin NixFiles` in the teminal. This will setup the basic configuration for the system, this generate a configuration for you from the files located in the `darwin` directory.
 2. The next step is to go into the `NixFiles` directory this can be achieved by running `cd NixFiles`.
 3. Now we you need to read over the configuration files and make any changes that you see fit, some of these must include changing your username and hostname.
-4. You now must rebuild this configuration we can do this with `darwin-rebuild switch --flake .`. This assumes that your host name has not changed.
+4. You now must rebuild this configuration we can do this with `nix run darwin-rebuild -- switch --flake .#hostname` hostname should be subsituted for your systems hostname.
+5. After your first run you are now able to use the `darwin-rebuild switch --flake .` command to rebuild your system.
 
 #### With Linux
 


### PR DESCRIPTION
Just some quick fixes around the documentation relating to nix-darwin. The biggest one was assuming the user had `darwin-rebuild` before starting however this is not the case. The command was altered to be more inline with the other docs.