### PR TITLE
pass nixpkgs directly in forAllSystems, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are 3 main templates in this repository:
 
 #### With Darwin (macOS)
 
-1. Run `nix flake new -t github:auxolotl/templates#darwin NixFiles` in the teminal. This will setup the basic configuration for the system, this generate a configuration for you from the files located in the `darwin` directory.
+1. Run `nix flake new -t github:auxolotl/templates#darwin NixFiles` in the terminal. This will setup the basic configuration for the system, this generate a configuration for you from the files located in the `darwin` directory.
 2. The next step is to go into the `NixFiles` directory this can be achieved by running `cd NixFiles`.
 3. Now we you need to read over the configuration files and make any changes that you see fit, some of these must include changing your username and hostname.
 4. You now must rebuild this configuration we can do this with `darwin-rebuild switch --flake .`. This assumes that your host name has not changed.

--- a/darwin/core.nix
+++ b/darwin/core.nix
@@ -13,7 +13,7 @@
     # this allows the system builder to use substitutes
     builders-use-substitutes = true;
 
-    # we want these beacuse we don't have to build every package from source
+    # we want these because we don't have to build every package from source
     substituters = [ "https://nix-community.cachix.org" ];
     trusted-public-keys = [ "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" ];
 

--- a/darwin/flake.nix
+++ b/darwin/flake.nix
@@ -11,7 +11,7 @@
 
       # The `follows` keyword in inputs is used for inheritance.
       # we do this in order to prevent duplication of the nixpkgs input, and potential
-      # issues with diffrent versions of given packages.
+      # issues with different versions of given packages.
       # However, it should be noted that this can lead to having to rebuild packages from source.
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/darwin/home.nix
+++ b/darwin/home.nix
@@ -3,7 +3,7 @@
   # Home Manager needs a bit of information about you and the
   # paths it should manage.
   home = {
-    # rember we set this in our flake.nix file
+    # remember we set this in our flake.nix file
     username = username;
     homeDirectory = "/Users/${username}";
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
           "aarch64-linux"
           "x86_64-darwin"
           "aarch64-darwin"
-        ] (system: function system);
+        ] (system: function nixpkgs.legacyPackages.${system});
     in
     {
       templates = {
@@ -31,6 +31,6 @@
           description = "";
         };
       };
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
     };
 }

--- a/home-manager/flake.nix
+++ b/home-manager/flake.nix
@@ -9,7 +9,7 @@
 
       # The `follows` keyword in inputs is used for inheritance.
       # we do this in order to prevent duplication of the nixpkgs input, and potential
-      # issues with diffrent versions of given packages.
+      # issues with different versions of given packages.
       # However, it should be noted that this can lead to having to rebuild packages from source.
       inputs.nixpkgs.follows = "nixpkgs";
     };


### PR DESCRIPTION
Giving `system` directly as an argument is more annoying in most situations than not - a good example being how the formatter output is set. Passing `nixpkgs.legacyPackages.${system}` directly allows for more concise access to what callers usually want (`pkgs`), and can also help avoid boilerplate in other situations (i.e., destructuring `pkgs` into `{lib, pkgs, system, ...}` instead of `system: let pkgs = nixpkgs.legacyPackages.${system}; inherit (pkgs) lib; in ...`)
