### PR TITLE
use standard module system more over specialArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ There are 3 main templates in this repository:
 1. Run `nix flake new -t github:auxolotl/templates#darwin NixFiles` in the terminal. This will setup the basic configuration for the system, this generate a configuration for you from the files located in the `darwin` directory.
 2. The next step is to go into the `NixFiles` directory this can be achieved by running `cd NixFiles`.
 3. Now we you need to read over the configuration files and make any changes that you see fit, some of these must include changing your username and hostname.
-4. You now must rebuild this configuration we can do this with `nix run darwin-rebuild -- switch --flake .#hostname` hostname should be subsituted for your systems hostname.
+4. You now must rebuild this configuration we can do this with `nix run darwin -- switch --flake .#hostname` hostname should be substituted for your systems hostname.
 5. After your first run you are now able to use the `darwin-rebuild switch --flake .` command to rebuild your system.
 
-#### With Linux
+#### With NixOS
 
 1. Run `nix flake new -t github:auxolotyl/templates#system NixFiles`
 2. Move into your new system with `cd NixFiles`
-3. Fill in your `hostName` and `username` in `flake.nix`
+3. Fill in your `hostName` in `flake.nix`
 4. Run `nixos-generate-config --show-hardware-config > hardware-configuration.nix` to generate configuration based on your filesystems and drivers
-5. Run `sudo nixos-rebuild build --flake .#hostName`, replacing hostName with your new hostName
+5. Run `nixos-rebuild build --flake .#hostName`, replacing hostName with your new hostName
 
 Congratulations, you are now using Aux!
 

--- a/darwin/home.nix
+++ b/darwin/home.nix
@@ -1,11 +1,10 @@
-{ username, ... }:
+{ config, ... }:
 {
   # Home Manager needs a bit of information about you and the
   # paths it should manage.
   home = {
     # remember we set this in our flake.nix file
-    username = username;
-    homeDirectory = "/Users/${username}";
+    homeDirectory = "/Users/${config.home.username}";
 
     # This value determines the Home Manager release that your
     # configuration is compatible with. This helps avoid breakage

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -1,3 +1,4 @@
+{ config, ... }:
 {
   config = {
     environment = {

--- a/darwin/system.nix
+++ b/darwin/system.nix
@@ -2,6 +2,9 @@
 # see <https://daiderd.com/nix-darwin/manual/index.html#sec-options> for more options
 {
   system = {
+    # remember to set the hostname in the kernel command line
+    defaults.smb.NetBIOSName = config.networking.hostName;
+
     # Add ability to used TouchID for sudo authentication
     security.pam.enableSudoTouchIdAuth = true;
 

--- a/darwin/users.nix
+++ b/darwin/users.nix
@@ -1,9 +1,0 @@
-{ username, hostname, ... }:
-{
-  # remember to set the hostname in the kernel command line
-  networking.hostName = hostname;
-  networking.computerName = hostname;
-  system.defaults.smb.NetBIOSName = hostname;
-
-  users.users."${username}".home = "/Users/${username}";
-}

--- a/home-manager/flake.nix
+++ b/home-manager/flake.nix
@@ -16,7 +16,7 @@
   };
 
   outputs =
-    { nixpkgs, home-manager, ... }:
+    inputs@{ nixpkgs, home-manager, ... }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -28,13 +28,17 @@
 
         # Specify your home configuration modules here, for example,
         # the path to your home.nix.
-        modules = [ ./home.nix ];
+        modules = [
+          ./home.nix
 
-        extraSpecialArgs = {
-          inherit username pkgs; # We inherit pkgs
-        };
+          { home.username = username; }
+        ];
+
         # Optionally use extraSpecialArgs
         # to pass through arguments to home.nix
+        extraSpecialArgs = {
+          inherit inputs;
+        };
       };
     };
 }

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -1,15 +1,9 @@
-{
-  config,
-  pkgs,
-  username,
-  ...
-}:
+{ config, pkgs, ... }:
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
   home = {
-    inherit username;
-    homeDirectory = "/home/${username}";
+    homeDirectory = "/home/${config.home.username}";
 
     # This value determines the Home Manager release that your configuration is
     # compatible with. This helps avoid breakage when a new Home Manager release

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -2,8 +2,6 @@
   config,
   lib,
   pkgs,
-  username,
-  hostName,
   ...
 }:
 
@@ -17,7 +15,6 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  networking.hostName = hostName; # Define your hostname.
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
   # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.
@@ -59,7 +56,7 @@
   # services.xserver.libinput.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
-  users.users.${username} = {
+  users.users.axol = {
     isNormalUser = true;
     extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
     packages = with pkgs; [ firefox ];

--- a/system/flake.nix
+++ b/system/flake.nix
@@ -4,17 +4,20 @@
   inputs.nixpkgs.url = "github:auxolotl/nixpkgs/nixpkgs-unstable";
 
   outputs =
-    { nixpkgs, ... }:
+    inputs@{ nixpkgs, ... }:
     let
       system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
       hostName = builtins.abort "You need to fill in your hostName"; # Set this variable equal to your hostName
-      username = builtins.abort "You need to fill in your username"; # Set this variable equal to your username
     in
     {
       nixosConfigurations.${hostName} = nixpkgs.lib.nixosSystem {
         inherit system;
-        modules = [ ./configuration.nix ];
+        modules = [
+          ./configuration.nix
+
+          { networking.hostName = hostName; }
+        ];
+
         specialArgs = {
           inherit inputs;
         };


### PR DESCRIPTION
currently, the use of specialArgs has a large overlap with standard (and documented) configuration options. i think we should be using these through `config` instead, rather than setting the example of passing simple string values like these to specialArgs only to use them in one or two options. this would: 

- show newer users that this is possible and a good way to reuse values for anything they configure
- keep these templates away from being too "alien" compared to the existing nix ecosystem
- give more examples of how the `modules` argument works outside of just taking in paths to files