### PR TITLE
chore: ignore template `flake.lock`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .direnv/
+*/flake.lock


### PR DESCRIPTION
as the templates should be locked locally on the user's machine, a gitignore entry was added to allow maintainers/contributors to test templates locally without accidentally committing the lockfile