### PR TITLE
fix(darwin): config argument missing on system.nix

### DIFF
--- a/darwin/system.nix
+++ b/darwin/system.nix
@@ -1,3 +1,4 @@
+{config, ...}:
 # This section apply settings to the system configuration only available on macOS
 # see <https://daiderd.com/nix-darwin/manual/index.html#sec-options> for more options
 {


### PR DESCRIPTION
Small typo on the darwin flake