### PR TITLE
docs: fixed typos and added feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are 3 main templates in this repository:
 
 #### With Darwin (macOS)
 
-1. Run `nix flake new -t github:auxolotl/templates#darwin NixFiles` in the terminal. This will setup the basic configuration for the system, this generate a configuration for you from the files located in the `darwin` directory.
+1. Run `nix --extra-experimental-features nix-command --extra-experimental-features flake new -t github:auxolotl/templates#darwin NixFiles` in the terminal. This will setup the basic configuration for the system, this generate a configuration for you from the files located in the `darwin` directory.
 2. The next step is to go into the `NixFiles` directory this can be achieved by running `cd NixFiles`.
 3. Now we you need to read over the configuration files and make any changes that you see fit, some of these must include changing your username and hostname.
 4. You now must rebuild this configuration we can do this with `nix run darwin -- switch --flake .#hostname` hostname should be substituted for your systems hostname.
@@ -30,7 +30,7 @@ There are 3 main templates in this repository:
 
 #### With NixOS
 
-1. Run `nix flake new -t github:auxolotyl/templates#system NixFiles`
+1. Run `nix --extra-experimental-features nix-command --extra-experimental-features flake new -t github:auxolotl/templates#system NixFiles`
 2. Move into your new system with `cd NixFiles`
 3. Fill in your `hostName` in `flake.nix`
 4. Run `nixos-generate-config --show-hardware-config > hardware-configuration.nix` to generate configuration based on your filesystems and drivers
@@ -40,6 +40,6 @@ Congratulations, you are now using Aux!
 
 #### With Home-manager
 
-1. Run `nix flake new -t github:auxolotyl/templates#home-manager NixFiles` to start
+1. Run `nix --extra-experimental-features nix-command --extra-experimental-features flake new -t github:auxolotl/templates#home-manager NixFiles` to start
 2. Move into your new Nix system with `cd NixFiles`
 3. Fill in your `username` in `flake.nix`


### PR DESCRIPTION
For those who are using the NixOS installer, flakes are not enabled yet, and so the commands listed wouldn't work. It does bubble an error, but adding the flags after the first `nix` command doesn't work, and it doesn't make this clear -- might as well add it here. 

Also, there were some errors in the URL name. 