### PR TITLE
treewide: replace system variables with a local module system

### DIFF
--- a/darwin/system.nix
+++ b/darwin/system.nix
@@ -1,4 +1,4 @@
-{config, ...}:
+{ config, ... }:
 # This section apply settings to the system configuration only available on macOS
 # see <https://daiderd.com/nix-darwin/manual/index.html#sec-options> for more options
 {

--- a/system/flake.nix
+++ b/system/flake.nix
@@ -6,16 +6,15 @@
   outputs =
     inputs@{ nixpkgs, ... }:
     let
-      system = "x86_64-linux";
       hostName = builtins.abort "You need to fill in your hostName"; # Set this variable equal to your hostName
     in
     {
       nixosConfigurations.${hostName} = nixpkgs.lib.nixosSystem {
-        inherit system;
         modules = [
           ./configuration.nix
+          ./options.nix
 
-          { networking.hostName = hostName; }
+          { aux.hostname = hostName; }
         ];
 
         specialArgs = {

--- a/system/options.nix
+++ b/system/options.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+let
+  inherit (lib.options) mkOption;
+  inherit (lib.types) str;
+in
+{
+  # More options can be added here.
+  # Following the module system, any module option added in the `options.aux` attribute set
+  # will become available under `config.aux` within your configuration. Thus making it
+  # possible to reference arbitrary internal variables if they have been set here
+  options.aux = {
+    hostname = mkOption {
+      type = str;
+      default = builtins.throw "hostname is required";
+      description = "The hostname for the machine";
+    };
+  };
+
+  config = {
+    # internally set `networking.hostName` to the value of `aux.hostname`
+    # similarly, you can set the values of nixpkgs module system options
+    # to the variable options defined under `options.aux`
+    networking.hostName = config.aux.hostname;
+  };
+}


### PR DESCRIPTION
Currently just a draft. I'd like to hear a bit from others to see if this is a change worth pursuing, or if it gets deemed too complicated.

- Formats darwin template with nixfmt
- Replaces the local variables in flake.nix with a module system the user can expand
- Removes `system` that was passed to nixosSystem, which is [actually not necessary](https://github.com/NixOS/nixpkgs/blob/ba10489eae3b2b2f665947b516e7043594a235c8/nixos/lib/eval-config.nix#L12-L15). I will replace this with `nixpkgs.hostPlatform` in a future commit, but that is going to be in the generated hardware-configuration.nix so it may not be necessary.