### PR TITLE
feat: rust template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,10 @@
           path = ./direnv;
           description = "An empty devshell with direnv support";
         };
+        rust = {
+          path = ./rust;
+          description = "Rust specific template providing packaging, dev-shell & cross-compilation; based on fenix.";
+        };
       };
       formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
     };

--- a/rust/.editorconfig
+++ b/rust/.editorconfig
@@ -9,6 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.nix]
+indent_style = space
 indent_size = 2
 insert_final_newline = false
 
@@ -22,6 +23,7 @@ trim_trailing_whitespace = false
 insert_final_newline = false
 
 [*.{json,json5,yaml,yml,webmanifest}]
+indent_style = space
 indent_size = 2
 
 [*.toml]

--- a/rust/.editorconfig
+++ b/rust/.editorconfig
@@ -1,0 +1,36 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.nix]
+indent_size = 2
+insert_final_newline = false
+
+[*.rs,Cargo.toml]
+indent_size = 4
+insert_final_newline = false
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.{json,json5,yaml,yml,webmanifest}]
+indent_size = 2
+
+[*.toml]
+indent_style = unset
+indent_size = 0
+
+[*.lock]
+indent_style = unset
+insert_final_newline = unset
+
+[Makefile]
+indent_style = tab

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+result
+target/

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,0 +1,6 @@
+# placeholder for the real Cargo.lock,
+# so that evaluating the flake does not fail due to missing files,
+# before using `cargo init` to create the 'real' files
+version = 3
+
+[[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,9 @@
+# placeholder for the real Cargo.toml,
+# so that evaluating the flake does not fail due to missing files,
+# before using `cargo init` to create the 'real' files
+[package]
+name = "bin"
+version = "0.1.0"
+
+[profile.release]
+overflow-checks = true

--- a/rust/default.nix
+++ b/rust/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -11,10 +11,6 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
-    nix-filter = {
-      url = "github:numtide/nix-filter";
-    };
   };
 
   outputs =
@@ -22,7 +18,6 @@
       self,
       nixpkgs,
       fenix,
-      nix-filter,
       ...
     }@inputs:
     let
@@ -70,7 +65,6 @@
                   pkgsCross.callPackage (./. + "/nix/packages/${packageName}.nix") {
                     inherit cargoMeta;
                     flake-self = self;
-                    nix-filter = import inputs.nix-filter;
                     rustPlatform = pkgsCross.makeRustPlatform {
                       cargo = toolchain;
                       rustc = toolchain;
@@ -104,7 +98,6 @@
           ${packageName} = pkgs.callPackage (./. + "/nix/packages/${packageName}.nix") {
             inherit cargoMeta;
             flake-self = self;
-            nix-filter = import inputs.nix-filter;
             rustPlatform = pkgs.makeRustPlatform {
               cargo = fenix-channel.toolchain;
               rustc = fenix-channel.toolchain;

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -93,6 +93,29 @@
     {
       formatter = forSystems ({ pkgs, ... }: pkgs.alejandra);
 
+      checks = forSystems (
+        { pkgs, fenixChannel, ... }:
+        {
+          rustfmt =
+            pkgs.runCommand "check-rustfmt"
+              {
+                nativeBuildInputs =
+                  let
+                    fenixRustToolchain = fenixChannel.withComponents [
+                      "cargo"
+                      "rustfmt-preview"
+                    ];
+                  in
+                  [ fenixRustToolchain ];
+              }
+              ''
+                cd ${./.}
+                cargo fmt -- --check
+                touch $out
+              '';
+        }
+      );
+
       packages = forSystems (
         {
           pkgs,

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,0 +1,146 @@
+{
+  inputs = {
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+
+    nixpkgs.url = "github:NixOs/nixpkgs/nixos-unstable";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-filter = {
+      url = "github:numtide/nix-filter";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      fenix,
+      nix-filter,
+      ...
+    }@inputs:
+    let
+      cargoMeta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      packageName = cargoMeta.package.name;
+
+      forSystems =
+        function:
+        nixpkgs.lib.genAttrs [ "x86_64-linux" ] (
+          system:
+          let
+            pkgs = import nixpkgs {
+              inherit system;
+
+              overlays = [ (final: prev: { ${packageName} = self.packages.${system}.${packageName}; }) ];
+            };
+
+            fenix-pkgs = fenix.packages.${system};
+            fenix-channel = fenix-pkgs.toolchainOf {
+              channel = "nightly";
+              date =
+                builtins.replaceStrings [ "nightly-" ] [ "" ]
+                  (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
+              sha256 = "sha256-SzEeSoO54GiBQ2kfANPhWrt0EDRxqEvhIbTt2uJt/TQ=";
+            };
+
+            makeCrossPackage =
+              packageName: pkgsCross:
+              let
+                pkgs = builtins.throw "defining cross pkg, accessing pkgs is a bug";
+              in
+              {
+                "${packageName}-cross-${pkgsCross.stdenv.hostPlatform.config}${
+                  if pkgsCross.stdenv.hostPlatform.isStatic then "-static" else ""
+                }" =
+                  let
+                    toolchain =
+                      with fenix-pkgs;
+                      combine [
+                        minimal.cargo
+                        minimal.rustc
+                        targets.${pkgsCross.rust.lib.toRustTarget pkgsCross.stdenv.targetPlatform}.latest.rust-std
+                      ];
+                  in
+                  pkgsCross.callPackage (./. + "/nix/packages/${packageName}.nix") {
+                    inherit cargoMeta;
+                    flake-self = self;
+                    nix-filter = import inputs.nix-filter;
+                    rustPlatform = pkgsCross.makeRustPlatform {
+                      cargo = toolchain;
+                      rustc = toolchain;
+                    };
+                  };
+              };
+          in
+          function {
+            inherit
+              system
+              pkgs
+              fenix-pkgs
+              fenix-channel
+              makeCrossPackage
+              ;
+          }
+        );
+    in
+    {
+      formatter = forSystems ({ pkgs, ... }: pkgs.alejandra);
+
+      packages = forSystems (
+        {
+          pkgs,
+          fenix-channel,
+          system,
+          makeCrossPackage,
+          ...
+        }:
+        {
+          ${packageName} = pkgs.callPackage (./. + "/nix/packages/${packageName}.nix") {
+            inherit cargoMeta;
+            flake-self = self;
+            nix-filter = import inputs.nix-filter;
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = fenix-channel.toolchain;
+              rustc = fenix-channel.toolchain;
+            };
+          };
+          default = self.packages.${system}.${packageName};
+        }
+        // makeCrossPackage packageName pkgs.pkgsCross.musl64.pkgsStatic
+        // makeCrossPackage packageName pkgs.pkgsCross.musl32.pkgsStatic
+        // makeCrossPackage packageName pkgs.pkgsCross.aarch64-multiplatform-musl.pkgsStatic
+        // makeCrossPackage packageName pkgs.pkgsCross.armv7l-hf-multiplatform.pkgsStatic
+        // makeCrossPackage packageName pkgs.pkgsCross.mingwW64.pkgsStatic
+      );
+
+      devShells = forSystems (
+        {
+          pkgs,
+          fenix-pkgs,
+          fenix-channel,
+          ...
+        }:
+        let
+          fenixRustToolchain = fenix-channel.withComponents [
+            "cargo"
+            "clippy-preview"
+            "rust-src"
+            "rustc"
+            "rustfmt-preview"
+          ];
+        in
+        {
+          default = pkgs.callPackage (./. + "/nix/dev-shells/${packageName}.nix") {
+            inherit fenixRustToolchain cargoMeta;
+          };
+          ci = pkgs.callPackage (./nix/dev-shells/ci.nix) { inherit fenixRustToolchain cargoMeta; };
+        }
+      );
+    };
+}

--- a/rust/justfile
+++ b/rust/justfile
@@ -1,0 +1,45 @@
+# move bin.nix files under nix/
+# to the correct place
+# for the new package name $packageName
+# (i.e. $packageName.nix)
+# delete this after running it
+setup packageName:
+    mv nix/dev-shells/bin.nix "nix/dev-shells/{{ packageName }}.nix"
+    mv nix/packages/bin.nix "nix/packages/{{ packageName }}.nix"
+    rm Cargo.lock Cargo.toml
+    # pass --vcs none to disable addition to .gitignore
+    # (which would add the Cargo.lock to it)
+    cargo init --vcs none --lib --edition 2021 --name "{{ packageName }}"
+    # generate inital lockfile
+    cargo build
+    # make sure nix sees new *.nix files
+    git add .
+
+build:
+    cargo build
+
+build-release:
+    cargo build --release
+
+run:
+    cargo run
+
+run-release:
+    cargo run --release
+
+format:
+    cargo fmt --check
+    eclint -exclude "{Cargo.lock,flake.lock}"
+
+format-fix:
+    cargo fmt
+    eclint -exclude "{Cargo.lock,flake.lock}" -fix
+
+lint:
+    cargo clippy
+
+lint-fix:
+    cargo clippy --fix
+
+reuse:
+    reuse lint

--- a/rust/nix/dev-shells/bin.nix
+++ b/rust/nix/dev-shells/bin.nix
@@ -1,0 +1,34 @@
+{
+  cargoMeta,
+  pkgs,
+  mkShell,
+  fenixRustToolchain,
+  bashInteractive,
+  cargo-edit,
+  reuse,
+  just,
+  eclint,
+}:
+
+mkShell {
+
+  inputsFrom = [ pkgs.${cargoMeta.package.name} ];
+
+  packages = [
+    fenixRustToolchain
+
+    bashInteractive
+
+    # for upgrading dependencies (i.e. versions in Cargo.toml)
+    cargo-edit
+
+    reuse
+    just
+    eclint
+  ];
+
+  shellHook = ''
+    unset SOURCE_DATE_EPOCH
+    just --list --list-heading $'just <task>:\n'
+  '';
+}

--- a/rust/nix/dev-shells/ci.nix
+++ b/rust/nix/dev-shells/ci.nix
@@ -1,0 +1,37 @@
+{
+  cargoMeta,
+  pkgs,
+  mkShell,
+  fenixRustToolchain,
+  bashInteractive,
+  reuse,
+  just,
+  eclint,
+  commitlint,
+}:
+
+mkShell {
+
+  inputsFrom = [ pkgs.${cargoMeta.package.name} ];
+
+  packages = [
+    fenixRustToolchain
+
+    bashInteractive
+
+    reuse
+    just
+    eclint
+    # nix develop ".#ci" --command --
+    #  eclint
+    #   -exclude "Cargo.lock"
+    #   -exclude "flake.lock"
+
+    commitlint
+    # nix develop ".#ci" --command --
+    #  commitlint
+    #   --color false --verbose
+    #   --from $(git rev-list --max-parents=0 HEAD | head -n 1)
+    #   --to HEAD
+  ];
+}

--- a/rust/nix/packages/bin.nix
+++ b/rust/nix/packages/bin.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  flake-self,
+  cargoMeta,
+  nix-filter,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  inherit (cargoMeta.package) version;
+  pname = cargoMeta.package.name;
+
+  src = nix-filter {
+    root = ../../.;
+    include = [
+      "src"
+      "Cargo.toml"
+      "Cargo.lock"
+    ];
+  };
+
+  cargoLock.lockFile = ../../Cargo.lock;
+
+  VERGEN_IDEMPOTENT = "1";
+  VERGEN_GIT_SHA =
+    if flake-self ? "rev" then
+      flake-self.rev
+    else if flake-self ? "dirtyRev" then
+      flake-self.dirtyRev
+    else
+      lib.warn "no git rev available" "NO_GIT_REPO";
+  VERGEN_GIT_BRANCH = if flake-self ? "ref" then flake-self.ref else "";
+  VERGEN_GIT_COMMIT_TIMESTAMP = flake-self.lastModifiedDate;
+}

--- a/rust/nix/packages/bin.nix
+++ b/rust/nix/packages/bin.nix
@@ -2,21 +2,23 @@
   lib,
   flake-self,
   cargoMeta,
-  nix-filter,
   rustPlatform,
 }:
-
+let
+  fs = lib.fileset;
+  sourceFiles = fs.unions [
+    (fs.maybeMissing ../../src)
+    (fs.maybeMissing ../../Cargo.toml)
+    (fs.maybeMissing ../../Cargo.lock)
+  ];
+in
 rustPlatform.buildRustPackage {
   inherit (cargoMeta.package) version;
   pname = cargoMeta.package.name;
 
-  src = nix-filter {
+  src = fs.toSource {
     root = ../../.;
-    include = [
-      "src"
-      "Cargo.toml"
-      "Cargo.lock"
-    ];
+    fileset = sourceFiles;
   };
 
   cargoLock.lockFile = ../../Cargo.lock;

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-12-21"
+components = ["rust-analyzer", "rust-src"]
+profile = "default"

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,0 +1,27 @@
+edition = "2021"
+version = "Two"
+
+newline_style = "Unix"
+format_generated_files = false
+
+hard_tabs = true
+tab_spaces = 4
+
+max_width = 80
+doc_comment_code_block_width = 80
+comment_width = 80
+error_on_line_overflow = true
+error_on_unformatted = true
+
+normalize_comments = true
+normalize_doc_attributes = true
+use_try_shorthand = true
+
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+
+reorder_impl_items = true
+
+match_block_trailing_comma = true
+
+use_field_init_shorthand = true

--- a/rust/shell.nix
+++ b/rust/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
As discussed [on the forum (Brainstorming: What should Rust support look like?)](https://forum.aux.computer/t/brainstorming-what-should-rust-support-look-like/455/10?u=liketechnik), this PR adds a rust template.

This PR is far from it's final form, with most stuff being either simply unpolished yet or up for discussion (many items on the lists taken from @getchoo's [excellent suggestions](https://forum.aux.computer/t/brainstorming-what-should-rust-support-look-like/455/8?u=liketechnik)):

Unpolished:

- [x] drop nix-filter as a dependency
    - we already have lib.filesystem that serves basically the same purpose. see [Working with local files — nix.dev documentation 1](https://nix.dev/tutorials/working-with-local-files)
- [x] better compose cross compilation toolchains
    - the current use of a function to both instantiate a toolchain and build a package is a bit messy
    - clearly separating supported cross targets, the instantiation of toolchains, and the overriding of a package using the standard toolchain from nixpkgs would allow for easier iteration
    - a good example of what i mean can be found in one of my repos [here](https://github.com/getchoo/teawieBot/blob/e93c0907be8d2169d2fd66e4d35ebac72528290f/nix/docker.nix#L9). it’s mainly used to create multi arch docker images from any arm or x64 machine on macos or linux
    - more callPackage in general would be good here

Discussion:

- [x] location
    - I opted for a `rust` sub-folder for now; although I think we landed on something like `lang-tooling/rust` in the discussion 
    - we also considered SIG specific template repos, but ultimately decided against them, regarding discoverability and the still to be determined exact structure of SIG repos
    - considering there's already a `c` folder too, `rust` should be fine
- [ ] use nixpkgs’ rust toolchain where possible and reasonable
    - for a standard build, there isn’t much reason to use fenix in the first place
    - this would make fenix another optional dependency, allowing for only depending on nixpkgs
    - the rust mirrors fenix and similar use are also very slow for users in countries such as china. hearing from people i know, being able to take advantage of local cache mirrors is much faster and more convenient
  - does it makes sense to add a second template showing how to use custom fenix / oxalica/rust-overlay / ... rust toolchains?
  - if we want a second template, I'd like to remove fenix last, so that I can just copy this template for the fenix one
- [ ] RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}" should be set in devShells with rust-analyer per [Rust - NixOS Wiki 1](https://wiki.nixos.org/wiki/Rust#Shell.nix_example)
    - I believe this is unnecessary due to the inclusion of `rust-src` as part of the components that make up the dev shell's rust toolchain
- [x] examples of checks would be nice
    - from the same project i linked before, i have a rustfmt check [here](https://github.com/getchoo/teawieBot/blob/e93c0907be8d2169d2fd66e4d35ebac72528290f/flake.nix#L49) for example
    - I've added the `rustfmt` check
    - I've also tried adding `clippy`, but that failed with an obscure "Permission denied" error
- [ ] the structure needs some reworking
    - this is mainly a nitpick about the requirement of some paths to use string concatenation. this is ugly and does have a (very minimal) performance impact in comparison to atomic expressions (i.e., standard paths)
    - agreed - should the files simply keep their current names and the string concatenations replaced by their paths?
- [ ] the template is quite opinionated in some additional places too:
    - justfile for common tasks
    - formatting (tabs instead of rustfmt defaults; further customisation of rustfmt.toml)

I'll work on the 'unpolished' parts before requesting reviews, so that we can focus on the 'discussion' part.