### PR TITLE
fix(system): remove ambigious `system` from `nixosSystem`

### DIFF
--- a/system/flake.nix
+++ b/system/flake.nix
@@ -11,11 +11,13 @@
     in
     {
       nixosConfigurations.${hostName} = nixpkgs.lib.nixosSystem {
-        inherit system;
         modules = [
           ./configuration.nix
 
-          { networking.hostName = hostName; }
+          {
+            networking.hostName = hostName;
+            nixpkgs.hostPlatform = system;
+          }
         ];
 
         specialArgs = {


### PR DESCRIPTION
Remove unnecessary `inherit system` that was passed nixosSystem, and replace it with `nixpkgs.hostSystem`. See [nixpkgs](https://github.com/NixOS/nixpkgs/blob/ba10489eae3b2b2f665947b516e7043594a235c8/nixos/lib/eval-config.nix#L12-L15) for my motivation.

The generated hardware-config will include this line *anyway*, so it could even be removed.